### PR TITLE
fix(texttest): enable `create_catalogues`, remove `collate_file`

### DIFF
--- a/test/GenerateProject/catalogue.tt
+++ b/test/GenerateProject/catalogue.tt
@@ -1,0 +1,3 @@
+The following new files/directories were created:
+<Test Directory>
+----.gitkeep

--- a/test/config.tt
+++ b/test/config.tt
@@ -7,8 +7,7 @@ filename_convention_scheme:standard
 # Expanded name to use for application
 full_name:Copier Test
 
-[collate_file]
-*:*
+create_catalogues:true
 
 [run_dependent_text]
 stderr:Copying from template version


### PR DESCRIPTION
* `collate_file` `*:*` doesnt handle subdirectories very well,
  better to collate specific files when needed
