### PR TITLE
fix(texttest): discard `stderr` for now

### DIFF
--- a/test/GenerateProject/stderr.tt
+++ b/test/GenerateProject/stderr.tt
@@ -1,6 +1,0 @@
-/opt/homebrew/Cellar/copier/9.1.0/libexec/lib/python3.12/site-packages/copier/vcs.py:199: DirtyLocalWarning: Dirty template changes included automatically.
-  warn(
-
-Copying from template version 0.0.0.post2.dev0+30f8eb2
-[36m identical[39m[0m  .
-[32m[1m    create[39m[0m  .gitkeep

--- a/test/config.tt
+++ b/test/config.tt
@@ -8,9 +8,4 @@ filename_convention_scheme:standard
 full_name:Copier Test
 
 create_catalogues:true
-
-[run_dependent_text]
-stderr:Copying from template version
-stderr:DirtyLocalWarning{LINES 2}
-stderr:No git tags found in template; using HEAD as ref
-
+discard_file:stderr


### PR DESCRIPTION
* `copier` doesnt produce a consistent output (order of files)
