### PR TITLE
feat(copier): assign a `copier`-specific template extension

### DIFF
--- a/copier.yaml
+++ b/copier.yaml
@@ -1,1 +1,2 @@
 _subdirectory: template
+_templates_suffix: .copier-jinja


### PR DESCRIPTION
* due to the extensive use of `jinja` templates in Salt formulas
