### PR TITLE
fix: generated `renovate` config didnt work for certain updates

### DIFF
--- a/template/.github/renovate.json5
+++ b/template/.github/renovate.json5
@@ -7,20 +7,28 @@
     "config:recommended",
     ":semanticCommitTypeAll(fix)",
   ],
-  // there are two match strings to match the two conditions
-  //   * no update needed
+  // There are two regex custom managers needed to match the two conditions
+  //   * no update currently needed
   //   * update needed but not yet applied
-  // renovate needs to be able to match both conditions for PRs to work properly
+  // `renovate` needs to be able to match both conditions for PRs to work properly
   "customManagers": [
     {
       "customType": "regex",
       "fileMatch": ["^.copier-answers.yml$"],
       "matchStrings": [
         "_commit: (?<currentValue>\\S+)\\n_src_path: gh:(?<depName>\\S+)\\n",
-        "_commit: \\S+ # __copier_update_needed (?<currentValue>\\S+)\\n_src_path: gh:(?<depName>.*)\\n",
       ],
       "datasourceTemplate": "github-tags",
       "autoReplaceStringTemplate": "_commit: {{{currentValue}}} # __copier_update_needed {{{newValue}}}\n_src_path: gh:{{{depName}}}\n",
-    }
-  ]
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^.copier-answers.yml$"],
+      "matchStrings": [
+        "# __copier_update_needed (?<currentValue>\\S+)\\n_src_path: gh:(?<depName>\\S+)\\n",
+      ],
+      "datasourceTemplate": "github-tags",
+      "autoReplaceStringTemplate": "# __copier_update_needed {{{newValue}}}\n_src_path: gh:{{{depName}}}\n",
+    },
+  ],
 }


### PR DESCRIPTION
* `renovate` changed the `_commit` value when a new update was detected
  before the prvious update had been applied