### PR TITLE
fix(texttest): resinstate `stderr` as it helps debugging template errors

### DIFF
--- a/test/GenerateProject/stderr.tt
+++ b/test/GenerateProject/stderr.tt
@@ -1,0 +1,8 @@
+/opt/homebrew/Cellar/copier/9.1.1/libexec/lib/python3.12/site-packages/copier/vcs.py:200: DirtyLocalWarning: Dirty template changes included automatically.
+  warn(
+
+Copying from template version 1.3.2.post1.dev0+c6db195
+[36m identical[39m[0m  .
+[32m[1m    create[39m[0m  .copier-answers.yml
+[32m[1m    create[39m[0m  .github
+[32m[1m    create[39m[0m  .github/renovate.json5

--- a/test/config.tt
+++ b/test/config.tt
@@ -5,7 +5,7 @@ executable:${TEXTTEST_ROOT}/../bin/copier
 filename_convention_scheme:standard
 
 # Expanded name to use for application
-full_name:Copier Test
+full_name:base-bootstrap
 
 create_catalogues:true
 

--- a/test/config.tt
+++ b/test/config.tt
@@ -8,4 +8,13 @@ filename_convention_scheme:standard
 full_name:Copier Test
 
 create_catalogues:true
-discard_file:stderr
+
+[run_dependent_text]
+stderr:Copying from template version
+stderr:DirtyLocalWarning{LINES 2}
+stderr:No git tags found in template; using HEAD as ref
+stderr:create [
+stderr:conflict [
+stderr:identical [
+stderr:overwrite [
+stderr:skip [


### PR DESCRIPTION
- **fix(texttest): resinstate `stderr` as it helps debugging template errors**
- **fix(texttest): set a useful testsuite name**
