### PR TITLE
fix: revert to default `renovate` settings re. semantic commits

### DIFF
--- a/template/.github/renovate.json5
+++ b/template/.github/renovate.json5
@@ -6,7 +6,6 @@
   ],
   "extends": [
     "config:recommended",
-    ":semanticCommitTypeAll(fix)",
   ],
   // `copier` template updates
   // There are two conditions that we need to account for


### PR DESCRIPTION
* the default follows `config:recommended` in this case
