### PR TITLE
ci: Revert "ci: fix `copier` dependency"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,6 @@ jobs:
       - name: Install test dependencies
         run: |
           pipx install copier
-          pipx inject copier 'pyyaml-include<2'
           pipx install texttest
       - name: Run `texttest`
         run: texttest -b


### PR DESCRIPTION
This reverts commit 7c47b00bd684dc9cce668c0c375af49b26f641de.
