### PR TITLE
fix(workflows): use correct `GITHUB_TOKEN` permissions for `sem-rel`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,6 +61,8 @@ jobs:
       - test
     permissions:
       contents: write
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0


### PR DESCRIPTION
* Fixes #83
