### PR TITLE
feat(workflows): wait for status checks to end before running `semantic-release`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,15 +61,17 @@ jobs:
         run: texttest -b
   results:
     name: Collect results
-    needs:
-      - pre-commit
-      - test
     permissions:
       contents: write
       issues: write
       pull-requests: write
+      checks: read
     runs-on: ubuntu-latest
     steps:
+      - uses: poseidon/wait-for-status-checks@v0.4.1
+        with:
+          ignore: Collect results
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - uses: codfish/semantic-release-action@9a999e0cdb207de2c9d9d4276860435727818989 # v3.4.1
         with:


### PR DESCRIPTION
* this is necessary for `Require status checks` to work properly
