### PR TITLE
ci(renovate): set automerge to always `merge-commit`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,6 +13,7 @@
     "helpers:pinGitHubActionDigests",
     "regexManagers:githubActionsVersions",
   ],
+  "automergeStrategy": "merge-commit",
   "customDatasources": {
     "python-versions": {
       "defaultRegistryUrlTemplate": "https://raw.githubusercontent.com/actions/python-versions/refs/heads/main/versions-manifest.json",


### PR DESCRIPTION
* as the Renovate default has changed to `squash` and this throws
  away information needed for `semantic-release`
