### PR TITLE
ci(renovate): enable automerging for `check-jsonschema` up to minor update types

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,4 +9,12 @@
     ':automergeStableNonMajor',
     ':semanticCommitTypeAll(fix)',
   ],
+  packageRules: [
+    {
+      matchDepNames: ['python-jsonschema/check-jsonschema'],
+      extends: [
+        ':automergeMinor',
+      ],
+    },
+  ],
 }


### PR DESCRIPTION
* as it is still in the v0.x.x version range
